### PR TITLE
Fix Java automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<inceptionYear>2021</inceptionYear>
 
 	<properties>
-		<automaticModuleName>org.simplejavamail.java-utils-mail-dkim</automaticModuleName>
+		<automaticModuleName>org.simplejavamail.java_utils_mail_dkim</automaticModuleName>
 		<!-- license plugin, see possible types here: -->
 		<!-- https://github.com/mathieucarbou/license-maven-plugin/tree/master/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates -->
 		<license.type>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.type>


### PR DESCRIPTION
A Java module name must match the syntax rules for a Java package. Therefore, no "-" signs are allowed there. In the current state, this very nice library unfortunately is not usable from a Java 17 modularized project.