### PR TITLE
Migrate to org.bouncycastle.bcpkix-jdk18on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>net.i2p.crypto</groupId>
-			<artifactId>eddsa</artifactId>
-			<version>0.3.0</version>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>1.78</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/simplejavamail/utils/mail/dkim/DkimSigner.java
+++ b/src/main/java/org/simplejavamail/utils/mail/dkim/DkimSigner.java
@@ -2,9 +2,10 @@ package org.simplejavamail.utils.mail.dkim;
 
 import jakarta.mail.Header;
 import jakarta.mail.MessagingException;
-import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.markenwerk.utils.data.fetcher.BufferedDataFetcher;
 import net.markenwerk.utils.data.fetcher.DataFetchException;
+
+import org.bouncycastle.jcajce.interfaces.EdDSAPrivateKey;
 import org.eclipse.angus.mail.util.CRLFOutputStream;
 import org.eclipse.angus.mail.util.QPEncoderStream;
 

--- a/src/main/java/org/simplejavamail/utils/mail/dkim/DomainKey.java
+++ b/src/main/java/org/simplejavamail/utils/mail/dkim/DomainKey.java
@@ -1,9 +1,9 @@
 package org.simplejavamail.utils.mail.dkim;
 
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -20,11 +20,9 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
-import net.i2p.crypto.eddsa.EdDSAPublicKey;
-import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
-import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 
 /**
  * A {@code DomainKey} holds the information about a domain key.
@@ -151,11 +149,10 @@ public final class DomainKey {
 
    private EdDSAPublicKey getEd25519PublicKey(String publicKeyTagValue) {
       try {
-         KeyFactory keyFactory = KeyFactory.getInstance(KeyPairType.ED25519.getJavaNotation());
-         EdDSAPublicKeySpec publicKeySpec = new EdDSAPublicKeySpec(Base64.getDecoder().decode(publicKeyTagValue),
-               EdDSANamedCurveTable.ED_25519_CURVE_SPEC);
-         return (EdDSAPublicKey) keyFactory.generatePublic(publicKeySpec);
-      } catch (NoSuchAlgorithmException nsae) {
+         byte[] keyBytes = Base64.getDecoder().decode(publicKeyTagValue);
+         KeyFactory keyFactory = KeyFactory.getInstance(KeyPairType.ED25519.getJavaNotation(), "BC");
+         return (EdDSAPublicKey) keyFactory.generatePublic(new X509EncodedKeySpec(keyBytes));
+      } catch (NoSuchAlgorithmException | NoSuchProviderException nsae) {
          throw new DkimException("Ed25519 algorithm not found by JVM");
       } catch (IllegalArgumentException e) {
          throw new DkimException("The public key " + publicKeyTagValue + " couldn't be read.", e);

--- a/src/main/java/org/simplejavamail/utils/mail/dkim/KeyPairType.java
+++ b/src/main/java/org/simplejavamail/utils/mail/dkim/KeyPairType.java
@@ -4,7 +4,7 @@ import java.security.Security;
 import java.util.Arrays;
 import java.util.List;
 
-import net.i2p.crypto.eddsa.EdDSASecurityProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public enum KeyPairType {
 
@@ -25,7 +25,7 @@ public enum KeyPairType {
       @Override
       protected void initialize() {
          if (!initailized) {
-            Security.addProvider(new EdDSASecurityProvider());
+            Security.addProvider(new BouncyCastleProvider());
             initailized = true;
          }
       }


### PR DESCRIPTION
## Problem Description 

This project used [net.i2p.crypto:eddsa](https://github.com/str4d/ed25519-java), which is vulnerable to CVE-2020-36843.

## Solution/Fix

Move from [net.i2p.crypto:eddsa](https://github.com/str4d/ed25519-java) to [org.bouncycastle.bcpkix-jdk18on](https://www.bouncycastle.org/download/bouncy-castle-java/)